### PR TITLE
add partial py.typed

### DIFF
--- a/src/atcoder-stubs/py.typed
+++ b/src/atcoder-stubs/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
Fixed an issue where type information for the original and stubs was not merged.

https://peps.python.org/pep-0561/#partial-stub-packages